### PR TITLE
0.0.x to 0.1.0 update (non-backward-compatible changes).

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,71 +1,81 @@
-Twitch API
-==========
+# Twitch API 0.1.0
 
 This gem simplifies the Twitch-API for ruby users.
-
-
 
 http://lak.in // http://twitter.com/dustinlakin
 
 
-Install
-----------------
+## Install
 
 With Rails:
 
-    #add to your Gemfile
-    gem 'twitch', '~> 0.0.5'
-
+```ruby
+#add to your Gemfile
+gem 'twitch', '~> 0.1.0'
+```
 
 Just irb or pry:
 
-    $ gem install twitch
+```ruby
+$ gem install twitch
 
+irb > require 'twitch'
+irb > @twitch = Twitch.new()
+```
 
-    irb > require 'twitch'
-    irb > @twitch = Twitch.new()
+## Changes in 0.1.0 from 0.0.x
 
+Listed below are some changes introduced in version 0.1.0 from 0.0.x. Some of the changes break backward compatibility with previous versions.
 
-Authorizing
-----------------
+```
+- Replaced camelCase method names with snake_case.
+- Removed 'get_' prefix from method names.
+- Made 'your_' prefix optional. (e.g. user() and your_user() are equal)
+```
+
+## Authorizing
 
 Step 1: Get url for your application - (@scope is an array of permissions, like ["user\_read", "channel\_read", "user\_follows_edit"])
 
+```ruby
+@twitch = Twitch.new({
+  client_id: @client_id,
+  secret_key: @secret_key,
+  redirect_uri: @redirect_uri,
+  scope: @scope
+})
 
-    @twitch = Twitch.new({
-      :client_id => @client_id,
-      :secret_key => @secret_key,
-      :redirect_uri => @redirect_uri,
-      :scope => @scope
-      })
-    @twitch.getLink()
+@twitch.link
+```
 
 Step 2: Authenticate and get access_token (this is done on your @redirect\_url)
 
-    @twitch = Twitch.new({
-      :client_id => @client_id,
-      :secret_key => @secret_key,
-      :redirect_uri => @redirect_uri,
-      :scope => @scope
-      })
-    @data = @twitch.auth(params[:code])
-    session[:access_token] = @data[:body]["access_token"]
+```ruby
+@twitch = Twitch.new({
+  client_id: @client_id,
+  secret_key: @secret_key,
+  redirect_uri: @redirect_uri,
+  scope: @scope
+})
+
+@data = @twitch.auth(params[:code])
+session[:access_token] = @data[:body]["access_token"]
+```
 
 Step 3: You can now use user token
 
-    @twitch = Twitch.new({ :access_token => session["access_token"]})
-    @yourself = @twitch.getYourUser()
+```ruby
+@twitch = Twitch.new access_token: session["access_token"]
+@yourself = @twitch.your_user()
+```
 
-
-
-
-Calls
-===========
+## Calls
 
 Calls will return a Hash with :body for the content of the call and a :response
 
-    user = "day9tv"
-    @twitch.getUser(user)
+```ruby
+@twitch.user "day9tv"
+```
 
 returns:
 
@@ -82,148 +92,184 @@ returns:
      :response=>200
     }
 
+## Usage
 
+### Users
 
-
-Users
------
-    #does not require any access_token 
-    # @twitch = Twitch.new() 
-    user = "day9tv"
-    @twitch.getUser(user)
-
-----
-    #requires access_token, use 
-    # @twitch = Twitch.new({ :access_token => session["access_token"]}))
-    @twitch.getYourUser()
-
-
-
-Teams
------
-    @twitch.getTeams()
-
-----
-    @twitch.getTeam("eg")
-
-
-Channels
------
-    @twitch.getChannel("lethalfrag")
-
-----
-    #Requires access_token
-    @twitch.getYourChannel()
-
-----
-    #Requires access_token (and special scope for channel editing)
-    #   editChannel(status, game)
-    #   arguments:
-    #    status (string)
-    #    game (string)
-    
-    @twitch.editChannel("Ranked Solo Queue", "League of Legends")
+```ruby
+#does not require any access_token 
+# @twitch = Twitch.new()
+@twitch.user "day9tv"
+```
 
 ----
 
-    #Requires access_token (and special scope for channel commercials)
-    #   runCommercial(channel, length = 30)
-    #   arguments:
-    #    channel (string)
-    #    length (int)
-    #  *this is untested*
+```ruby
+#requires access_token, use 
+# @twitch = Twitch.new access_token: session["access_token"]
+@twitch.your_user()
 
-    @twitch.runCommercial("lethalfrag", 30)
-    
+```
 
-Streams
------
-    @twitch.getStream("lethalfrag")
+### Teams
 
-  ----
-    # getStreams(options = {})
-    # see Twitch-API for options
-
-    @twitch.getStreams()
+```ruby
+@twitch.teams()
+```
 
 ----
-    # getFeaturedStreams(options = {})
-    # see Twitch-API for options
+
+```ruby
+@twitch.team "eg"
+```
+
+### Channels
+
+```ruby
+@twitch.channel "lethalfrag"
+```
 
 ----
-    @twitch.getFeaturedStreams()
+
+```ruby
+#Requires access_token
+@twitch.your_channel
+```
 
 ----
-    #Requires access_token
-    @twitch.getYourFollowedStreams()
+
+```ruby
+# Requires access_token (and special scope for channel editing)
+#   edit_channel(status, game)
+#   arguments:
+#    status (string)
+#    game (string)
+
+@twitch.edit_channel "Ranked Solo Queue", "League of Legends"
+```
+
+----
+
+```ruby
+#Requires access_token (and special scope for channel commercials)
+#   run_commercial(channel, length = 30)
+#   arguments:
+#    channel (string)
+#    length (int)
+#  *this is untested*
+
+@twitch.run_commercial "lethalfrag", 30
+```
+
+### Streams
+
+```ruby
+@twitch.stream "lethalfrag"
+```
+
+----
+
+```ruby
+# getStreams(options = {})
+# see Twitch-API for options
+
+@twitch.streams
+```
+
+----
+```ruby
+# getFeaturedStreams(options = {})
+# see Twitch-API for options
+```
+----
+```ruby
+@twitch.your_featured_streams
+```
+----
+```ruby
+#Requires access_token
+@twitch.your_followed_streams
+```
+
+### Games
+
+```ruby
+@twitch.top_games
+```
+
+### Search
 
 
-Games
------
-    @twitch.getTopGames()
+```ruby
+# search_streams(options = {})
+# see Twitch-API for options
+
+@twitch.search_streams
+```
+----
+
+```ruby
+# search_games(options = {})
+# see Twitch-API for options
+
+@twitch.search_games
+```
+
+### Videos
 
 
-Search
------
+```ruby
+# get_channel_videos(channel, options = {})
+# see Twitch-API for options
 
-    # searchStreams(options = {})
-    # see Twitch-API for options
+@twitch.channel_videos "lethalfrag"
+```
 
-    @twitch.searchStreams()
+----
+```ruby
+# get_video(video_id)
 
- ----
-    # searchGames(options = {})
-    # see Twitch-API for options
+@twitch.video 12345
+```
 
-    @twitch.searchGames()
+### Adapters
 
-
-Videos
------
-
-    # getChannelVideos(channel, options = {})
-    # see Twitch-API for options
-
-    @twitch.getChannelVideos("lethalfrag")
-
- ----
-    # getVideo(video_id)
-
-    @twitch.getVideo(12312123)
-
-Adapters
------
 
 To allow the gem to use different HTTP libraries, you can define an Adapter:
 
-    require 'open-uri' 
+```ruby
+require 'open-uri' 
 
-    module Twitch
-      module Adapters
-        class OpenURIAdapter < BaseAdapter
-          def self.request(method, url, options={})
-            if (method == :get)
-              ret = {}
+module Twitch
+  module Adapters
+    class OpenURIAdapter < BaseAdapter
+      def self.request(method, url, options={})
+        if (method == :get)
+          ret = {}
 
-              open(url) do |io|
-                ret[:body] = JSON.parse(io.read)
-                ret[:response] = io.status.first.to_i
-              end
-
-              ret
-            end
+          open(url) do |io|
+            ret[:body] = JSON.parse(io.read)
+            ret[:response] = io.status.first.to_i
           end
-        end # class OpenURIAdapter
-      end # module Adapters
-    end # module Twitch
+
+          ret
+        end
+      end
+    end # class OpenURIAdapter
+  end # module Adapters
+end # module Twitch
+```
 
 and then pass it into the Twitch class:
 
-    t = Twitch.new adapter: Twitch::Adapters::OpenURIAdapter
+```ruby
+@twitch = Twitch.new adapter: Twitch::Adapters::OpenURIAdapter
 
-    # or
+# or
 
-    t.adapter = Twitch::Adapters::OpenURIAdapter
+@twitch = Twitch.new
+@twitch.adapter = Twitch::Adapters::OpenURIAdapter
+```
 
 Adapters must be defined inside the Twitch::Adapters module, otherwise they will be considered invalid.
 Any invalid adapter passed to the library will revert to the default adapter.

--- a/lib/twitch/client.rb
+++ b/lib/twitch/client.rb
@@ -27,7 +27,7 @@ module Twitch
       get_adapter(adapter)
     end
 
-    def getLink
+    def link
       scope = ""
       @scope.each { |s| scope += s + '+' }
       link = "https://api.twitch.tv/kraken/oauth2/authorize?response_type=code&client_id=#{@client_id}&redirect_uri=#{@redirect_uri}&scope=#{scope}"
@@ -47,59 +47,74 @@ module Twitch
 
     # User
 
-    def getUser(user)
+    def user(user = nil)
+      return your_user unless user
+
       path = "/users/"
       url = @base_url + path + user;
+      
       get(url)
     end
 
-    def getYourUser
-      return false if !@access_token
+    def your_user
+      return false unless @access_token
+
       path = "/user?oauth_token=#{@access_token}"
       url = @base_url + path
+      
       get(url)
     end
 
     # Teams
 
-    def getTeams
+    def teams
       path = "/teams/"
       url = @base_url + path;
+      
       get(url)
     end
 
 
-    def getTeam(team_id)
+    def team(team_id)
       path = "/teams/"
       url = @base_url + path + team_id;
+      
       get(url)
     end
 
     # Channel
 
-    def getChannel(channel)
+    def channel(channel = nil)
+      return your_channel unless channel
+
       path = "/channels/"
       url = @base_url + path + channel;
+      
       get(url)
     end
 
-    def getYourChannel
-      return false if !@access_token
+    def your_channel
+      return false unless @access_token
+
       path = "/channel?oauth_token=#{@access_token}"
       url = @base_url + path;
+      
       get(url)
     end
     
-    def getEditors(channel)
-      return false if !@access_token
+    def editors(channel)
+      return false unless @access_token
+
       path = "/channels/#{channel}/editors?oauth_token=#{@access_token}"
       url = @base_url + path;
+      
       get(url)
     end
 
     # TODO: Add ability to set delay, which is only available for partered channels
-    def editChannel(channel, status, game)
-      return false if !@access_token
+    def edit_channel(channel, status, game)
+      return false unless @access_token
+
       path = "/channels/#{channel}/?oauth_token=#{@access_token}"
       url = @base_url + path
       data = {
@@ -111,29 +126,33 @@ module Twitch
       put(url, data)
     end
     
-    def resetKey(channel)
-      return false if !@access_token
+    def reset_key(channel)
+      return false unless @access_token
+
       path = "/channels/#{channel}/stream_key?oauth_token=#{@access_token}"
       url = @base_url + path
       delete(url)
     end
 
-    def followChannel(username, channel)
-      return false if !@access_token
+    def follow_channel(username, channel)
+      return false unless @access_token
+
       path = "/users/#{username}/follows/channels/#{channel}?oauth_token=#{@access_token}"
       url = @base_url + path
       put(url)
     end
     
-    def followChannel(username, channel)
-      return false if !@access_token
+    def follow_channel(username, channel)
+      return false unless @access_token
+
       path = "/users/#{username}/follows/channels/#{channel}?oauth_token=#{@access_token}"
       url = @base_url + path
       delete(url)
     end
 
-    def runCommercial(channel, length = 30)
-      return false if !@access_token
+    def run_commercial(channel, length = 30)
+      return false unless @access_token
+
       path = "/channels/#{channel}/commercial?oauth_token=#{@access_token}"
       url = @base_url + path
       post(url, {
@@ -141,143 +160,167 @@ module Twitch
       })
     end
     
-    def getChannelTeams(channel)
-      return false if !@access_token
+    def channel_teams(channel)
+      return false unless @access_token
+
       path = "/channels/#{channel}/teams?oauth_token=#{@access_token}"
       url = @base_url + path;
+      
       get(url)
     end
 
     # Streams
 
-    def getStream(stream_name)
+    def stream(stream_name)
       path = "/stream/#{stream_name}"
       url = @base_url + path;
+      
       get(url)
     end
 
-    def getStream(stream_name)
+    def stream(stream_name)
       path = "/streams/#{stream_name}"
       url = @base_url + path;
+      
       get(url)
     end
 
-    def getStreams(options = {})
-      query = buildQueryString(options)
+    def streams(options = {})
+      query = build_query_string(options)
       path = "/streams"
       url =  @base_url + path + query
+      
       get(url)
     end
 
-    def getFeaturedStreams(options = {})
-      query = buildQueryString(options)
+    def featured_streams(options = {})
+      query = build_query_string(options)
       path = "/streams/featured"
       url = @base_url + path + query
+      
       get(url)
     end
 
-    def getSummeraizedStreams(options = {})
-      query = buildQueryString(options)
+    def summarized_streams(options = {})
+      query = build_query_string(options)
       path = "/streams/summary"
       url = @base_url + path + query
+      
       get(url)
     end
 
-    def getYourFollowedStreams(options = {})
-      return false if !@access_token
-      query = buildQueryString(options)
+    def followed_streams(options = {})
+      return false unless @access_token
+
+      query = build_query_string(options)
       path = "/streams/followed?oauth_token=#{@access_token}"
       url = @base_url + path + query
+      
       get(url)
     end
+    alias :your_followed_streams :followed_streams
 
     #Games
 
-    def getTopGames(options = {})
-      query = buildQueryString(options)
+    def top_games(options = {})
+      query = build_query_string(options)
       path = "/games/top"
       url = @base_url + path + query
+      
       get(url)
     end
 
     #Search
     
-    def searchChannels(options = {})
-      query = buildQueryString(options)
+    def search_channels(options = {})
+      query = build_query_string(options)
       path = "/search/channels"
       url = @base_url + path + query
+      
       get(url)
     end
 
-    def searchStreams(options = {})
-      query = buildQueryString(options)
+    def search_streams(options = {})
+      query = build_query_string(options)
       path = "/search/streams"
       url = @base_url + path + query
+      
       get(url)
     end
 
-    def searchGames(options = {})
-      query = buildQueryString(options)
+    def search_games(options = {})
+      query = build_query_string(options)
       path = "/search/games"
       url = @base_url + path + query
+      
       get(url)
     end
 
     # Videos
 
-    def getChannelVideos(channel, options = {})
-      query = buildQueryString(options)
+    def channel_videos(channel, options = {})
+      query = build_query_string(options)
       path = "/channels/#{channel}/videos"
       url = @base_url + path + query
+      
       get(url)
     end
 
-    def getVideo(video_id)
+    def video(video_id)
       path = "/videos/#{video_id}/"
       url = @base_url + path
+      
       get(url)
     end
 
-    def isSubscribed(username, channel, options = {})
-      query = buildQueryString(options)
+    def subscribed?(username, channel, options = {})
+      query = build_query_string(options)
       path = "/users/#{username}/subscriptions/#{channel}?oauth_token=#{@access_token}"
       url = @base_url + path + query
+      
       get(url)
     end
     
-    def getYourFollowedVideos(options ={})
-      return false if !@access_token
-      query = buildQueryString(options)
+    def followed_videos(options ={})
+      return false unless @access_token
+
+      query = build_query_string(options)
       path = "/videos/followed?oauth_token=#{@access_token}"
       url = @base_url + path + query
+      
       get(url)
     end
+    alias :your_followed_videos :followed_videos
     
-    def getTopVideos(options = {})
-      query = buildQueryString(options)
+    def top_videos(options = {})
+      query = build_query_string(options)
       path = "/videos/top"
       url = @base_url + path + query
+      
       get(url)
     end
     
     # Blocks
     
-    def getBlocks(username, options = {})
-      query = buildQueryString(options)
+    def blocks(username, options = {})
+      query = build_query_string(options)
       path = "/users/#{username}/blocks?oauth_token=#{@access_token}"
       url = @base_url + path + query
+      
       get(url)
     end
     
-    def blockUser(username, target)
-      return false if !@access_token
+    def block_user(username, target)
+      return false unless @access_token
+
       path = "/users/#{username}/blocks/#{target}?oauth_token=#{@access_token}"
       url = @base_url + path
       put(url)
     end
     
-    def unblockUser(username, target)
-      return false if !@access_token
+    def unblock_user(username, target)
+      return false unless @access_token
+
       path = "/users/#{username}/blocks/#{target}?oauth_token=#{@access_token}"
       url = @base_url + path
       delete(url)
@@ -285,73 +328,85 @@ module Twitch
     
     # Chat
     
-    def getChatLinks(channel)
+    def chat_links(channel)
       path = "/chat/"
       url = @base_url + path + channel;
+      
       get(url)
     end
     
-    def getBadges(channel)
+    def badges(channel)
       path = "/chat/#{channel}/badges"
       url = @base_url + path;
+      
       get(url)
     end
     
-    def getEmoticons()
+    def emoticons()
       path = "/chat/emoticons"
       url = @base_url + path;
+      
       get(url)
     end
     
     # Follows
     
-    def getFollowing(channel)
+    def following(channel)
       path = "/channels/#{channel}/follows"
       url = @base_url + path;
+      
       get(url)
     end
     
-    def getFollowed(username)
+    def followed(username)
       path = "/users/#{username}/follows/channels"
       url = @base_url + path;
+      
       get(url)
     end
     
-    def getFollowStatus(username, channel)
+    def follow_status(username, channel)
       path = "/users/#{username}/follows/channels/#{channel}/?oauth_token=#{@access_token}"
       url = @base_url + path;
+      
       get(url)
     end
     
     # Ingests
     
-    def getIngests()
+    def ingests()
       path = "/ingests"
       url = @base_url + path
+      
       get(url)
     end
     
     # Root
     
-    def getRoot()
+    def root()
       path = "/?oauth_token=#{@access_token}"
       url = @base_url + path
+      
       get(url)
     end
     
     # Subscriptions
     
-    def getSubscribed(channel)
-      return false if !@access_token
+    def subscribed(channel)
+      return false unless @access_token
+
       path = "/channels/#{channel}/subscriptions?oauth_token=#{@access_token}"
       url = @base_url + path
+      
       get(url)
     end
     
-    def isSubscribedToChannel(username, channel)
-      return false if !@access_token
+    def subscribed_to_channel(username, channel)
+      return false unless @access_token
+
       path = "/channels/#{channel}/subscriptions/#{username}?oauth_token=#{@access_token}"
       url = @base_url + path
+      
       get(url)
     end
   end

--- a/lib/twitch/request.rb
+++ b/lib/twitch/request.rb
@@ -1,6 +1,6 @@
 module Twitch
   module Request
-    def buildQueryString(options)
+    def build_query_string(options)
       query = "?"
       options.each do |key, value|
         query += "#{key}=#{value.to_s.gsub(" ", "+")}&"

--- a/lib/twitch/version.rb
+++ b/lib/twitch/version.rb
@@ -2,8 +2,8 @@
 module Twitch
   module VERSION
     MAJOR = 0
-    MINOR = 0
-    TINY  = 5
+    MINOR = 1
+    TINY  = 0
 
     STRING = [MAJOR, MINOR, TINY].compact.join(".")
   end

--- a/spec/twitch_spec.rb
+++ b/spec/twitch_spec.rb
@@ -19,154 +19,154 @@ describe Twitch do
 			:redirect_uri => @redirect_uri,
 			:scope => ["user_read", "channel_read", "channel_editor", "channel_commercial", "channel_stream", "user_blocks_edit"]
 			})
-		expect(@t.getLink()).to eq "https://api.twitch.tv/kraken/oauth2/authorize?response_type=code&client_id=#{@client_id}&redirect_uri=#{@redirect_uri}&scope=#{@scope_str}"
+		expect( @t.link ).to eq "https://api.twitch.tv/kraken/oauth2/authorize?response_type=code&client_id=#{@client_id}&redirect_uri=#{@redirect_uri}&scope=#{@scope_str}"
 	end
 
 	it 'should get user (not authenticated)' do
 		@t = Twitch.new()
-		expect(@t.getUser("day9")[:response]).to eq 200
+		expect( @t.user("day9")[:response] ).to eq 200
 	end
 
 	it 'should get user (authenticated)' do
 		@t = Twitch.new({:access_token => @access_token})
-		expect(@t.getUser("day9")[:response]).to eq 200
+		expect( @t.user("day9")[:response] ).to eq 200
 	end
 
 	it 'should get authenticated user' do
 		@t = Twitch.new({:access_token => @access_token})
-		expect(@t.getYourUser()[:response]).to eq 200
+		expect( @t.user()[:response] ).to eq 200
 	end
 
 	it 'should not get authenticated user when not authenticated' do
 		@t = Twitch.new()
-		expect(@t.getYourUser()).to eq false
+		expect( @t.user() ).to eq false
 	end
 
 	it 'should get all teams' do
 		@t = Twitch.new()
-		expect(@t.getTeams()[:response]).to eq 200
+		expect( @t.teams()[:response] ).to eq 200
 	end
 
 	it 'should get single team' do
 		@t = Twitch.new()
-		expect(@t.getTeam("eg")[:response]).to eq 200
+		expect( @t.team("eg")[:response] ).to eq 200
 	end
 
 
 	it 'should get single channel' do
 		@t = Twitch.new()
-		expect(@t.getChannel("day9tv")[:response]).to eq 200
+		expect( @t.channel("day9tv")[:response] ).to eq 200
 	end
 
 	it 'should get your channel' do
 		@t = Twitch.new({:access_token => @access_token})
-		expect(@t.getYourChannel()[:response]).to eq 200
+		expect( @t.channel()[:response] ).to eq 200
 	end
 
 	it 'should edit your channel' do
 		@t = Twitch.new({:access_token => @access_token})
-		expect(@t.editChannel("Changing API", "Diablo III")[:response]).to eq 200
+		expect( @t.edit_channel("Changing API", "Diablo III")[:response] ).to eq 200
 	end
 
 	# it 'should run a comercial on your channel' do
 	# 	@t = Twitch.new({:access_token => @access_token})
-	#   expect(@t.runCommercial("dustinlakin")[:response]).to eq 204
+	#   expect( @t.runCommercial("dustinlakin")[:response] ).to eq 204
 	# end
 
 	it 'should get a single user stream' do
 		@t = Twitch.new()
-		expect(@t.getStream("nasltv")[:response]).to eq 200
+		expect( @t.stream("nasltv")[:response] ).to eq 200
 	end
 
 	it 'should get all streams' do
 		@t = Twitch.new()
-		expect(@t.getStreams()[:response]).to eq 200
+		expect( @t.streams()[:response] ).to eq 200
 	end
 
 	it 'should get League of Legends streams with +' do
 		@t = Twitch.new()
-		expect(@t.getStreams({:game => "League+of+Legends"})[:response]).to eq 200
+		expect( @t.streams({:game => "League+of+Legends"})[:response] ).to eq 200
 	end
 
 	it 'should get League of Legends streams with spaces' do
 		@t = Twitch.new()
-		expect(@t.getStreams({:game => "League of Legends"})[:response]).to eq 200
+		expect( @t.streams({:game => "League of Legends"})[:response] ).to eq 200
 	end
 
 	it 'should get featured streams' do
 		@t = Twitch.new()
-		res = @t.getFeaturedStreams()
+		res = @t.featured_streams()
 
-		expect(res[:response]).to eq 200
-		expect(res[:body]["featured"].length).to eq 25
+		expect(res[:response] ).to eq 200
+		expect(res[:body]["featured"].length ).to eq 25
 	end
 
 	it 'should get more featured streams' do
 		@t = Twitch.new()
-		res = @t.getFeaturedStreams({:limit => 100})
+		res = @t.featured_streams({:limit => 100})
 
-		expect(res[:response]).to eq 200
+		expect(res[:response] ).to eq 200
 		expect(res[:body]["featured"].length).to be > 25
 	end
 	
 	it 'should get chat links' do
 	  @t = Twitch.new()
-	  expect(@t.getChatLinks("day9tv")[:response]).to eq 200
+	  expect( @t.chat_links("day9tv")[:response] ).to eq 200
 	end
 	
 	it 'should get chat badges' do
 	  @t = Twitch.new()
-	  expect(@t.getBadges("day9tv")[:response]).to eq 200
+	  expect( @t.badges("day9tv")[:response] ).to eq 200
 	end
 	
 	it 'should get chat emoticons' do
 	  @t = Twitch.new()
-	  expect(@t.getEmoticons()[:response]).to eq 200
+	  expect( @t.emoticons()[:response] ).to eq 200
 	end
 	
 	it 'should get channel followers' do
 	  @t = Twitch.new()
-	  expect(@t.getFollowing("day9tv")[:response]).to eq 200
+	  expect( @t.following("day9tv")[:response] ).to eq 200
 	end
 	
 	it 'should get channels followed by user' do
 	  @t = Twitch.new()
-	  expect(@t.getFollowed("day9")[:response]).to eq 200
+	  expect( @t.followed("day9")[:response] ).to eq 200
 	end
 	
 	it 'should get status of user following channel' do
 	  @t = Twitch.new()
-	  expect(@t.getFollowStatus("day9", "day9tv")[:response]).to eq 404
+	  expect( @t.follow_status("day9", "day9tv")[:response] ).to eq 404
 	end
 	
 	it 'should get ingests' do
 	  @t = Twitch.new()
-	  expect(@t.getIngests[:response]).to eq 200
+	  expect( @t.ingests[:response] ).to eq 200
 	end
 	
 	it 'should get root' do
 	  @t = Twitch.new()
-	  expect(@t.getRoot[:response]).to eq 200
+	  expect( @t.root[:response] ).to eq 200
 	end
 	
 	it 'should get your followed streams' do
 	  @t = Twitch.new()
-	  expect(@t.getYourFollowedStreams).to eq false
+	  expect( @t.followed_streams() ).to eq false
 	end
 	
 	it 'should get your followed videos' do
 	  @t = Twitch.new()
-	  expect(@t.getYourFollowedVideos).to eq false
+	  expect( @t.followed_videos() ).to eq false
 	end
 	
 	it 'should get top games' do
 	  @t = Twitch.new()
-	  expect(@t.getTopGames[:response]).to eq 200
+	  expect( @t.top_games[:response] ).to eq 200
 	end
 	
 	it 'should get top videos' do
 	  @t = Twitch.new()
-	  expect(@t.getTopVideos[:response]).to eq 200
+	  expect( @t.top_videos[:response] ).to eq 200
 	end
 
 	it 'should have a default adapter' do
@@ -199,9 +199,9 @@ describe Twitch do
 
 		t = Twitch.new adapter: Twitch::Adapters::OpenURIAdapter
 
-		res = t.getFeaturedStreams
+		res = t.featured_streams
 
-		expect( res[:response]          ).to eq 200
+		expect( res[:response]                ).to eq 200
 		expect( res[:body]["featured"].length ).to eq 25
 	end
 
@@ -217,3 +217,4 @@ describe Twitch do
 	end
 
 end
+


### PR DESCRIPTION
Some of the updates in this commit break backward-compatibility with previous
versions, so I've upped the version number to 0.1.0.

The reason for jumping to 0.x.0 from 0.0.x is so people using ~> in a Gemfile won't receive
this version, meaning their code will still work with the old syntax until they update.

###### Changes
    * Replace camelCasing with snake_casing to follow ruby conventions.

    * Remove 'get_' prefix to allow method names to more closely 
      match API URI. (e.g. @t.teams() -> '/teams')

    * Make 'your_' method prefix optional (e.g. user() (with no arguments) and 
      your_user() are equal)

    * Update README.md to use ruby syntax highlighting and reflect above changes.

###### Tests
```
Finished in 22.12 seconds (files took 1.12 seconds to load)
31 examples, 3 failures
```
The 3 failures are the same failures as mentioned in the last commit.