### PR TITLE
Updated handling of oauth_token querystring parameter to fix bug when passing in additional options

### DIFF
--- a/lib/twitch/client.rb
+++ b/lib/twitch/client.rb
@@ -212,8 +212,9 @@ module Twitch
     def followed_streams(options = {})
       return false unless @access_token
 
+      options[:oauth_token] = @access_token
       query = build_query_string(options)
-      path = "/streams/followed?oauth_token=#{@access_token}"
+      path = "/streams/followed"
       url = @base_url + path + query
       
       get(url)
@@ -274,8 +275,9 @@ module Twitch
     end
 
     def subscribed?(username, channel, options = {})
+      options[:oauth_token] = @access_token
       query = build_query_string(options)
-      path = "/users/#{username}/subscriptions/#{channel}?oauth_token=#{@access_token}"
+      path = "/users/#{username}/subscriptions/#{channel}"
       url = @base_url + path + query
       
       get(url)
@@ -284,8 +286,9 @@ module Twitch
     def followed_videos(options ={})
       return false unless @access_token
 
+      options[:oauth_token] = @access_token
       query = build_query_string(options)
-      path = "/videos/followed?oauth_token=#{@access_token}"
+      path = "/videos/followed"
       url = @base_url + path + query
       
       get(url)
@@ -303,8 +306,9 @@ module Twitch
     # Blocks
     
     def blocks(username, options = {})
+      options[:oauth_token] = @access_token
       query = build_query_string(options)
-      path = "/users/#{username}/blocks?oauth_token=#{@access_token}"
+      path = "/users/#{username}/blocks"
       url = @base_url + path + query
       
       get(url)


### PR DESCRIPTION
If you call one of the methods that uses the oauth_token querystring parameter and pass in additional options to that method, the resultant querystring is malformed.

For example:
twitch.your_followed_streams({ limit: 100 })

Results in a querystring of:
https://api.twitch.tv/kraken/streams/followed?oauth_token=pzgp42sjt52rgfh59vdez2zu95sioc?limit=100

Note the double question mark.

This fix updates the methods to treat oauth_token like any other querystring parameter.
