### PR TITLE
Add params to following/followed requests and update tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,38 @@
+PATH
+  remote: .
+  specs:
+    twitch (0.1.2)
+      httparty
+      json
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    diff-lcs (1.2.5)
+    httparty (0.13.7)
+      json (~> 1.8)
+      multi_xml (>= 0.5.2)
+    json (1.8.3)
+    multi_xml (0.5.5)
+    rspec (3.0.0)
+      rspec-core (~> 3.0.0)
+      rspec-expectations (~> 3.0.0)
+      rspec-mocks (~> 3.0.0)
+    rspec-core (3.0.3)
+      rspec-support (~> 3.0.0)
+    rspec-expectations (3.0.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.0.0)
+    rspec-mocks (3.0.3)
+      rspec-support (~> 3.0.0)
+    rspec-support (3.0.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  rspec
+  twitch!
+
+BUNDLED WITH
+   1.11.2

--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ returns:
 @twitch.channel "lethalfrag"
 ```
 
+```ruby
+@twitch.channel_panels "lethalfrag"
+```
+
 ----
 
 ```ruby
@@ -160,6 +164,15 @@ returns:
 
 @twitch.run_commercial "lethalfrag", 30
 ```
+
+### Follows
+
+```@twitch.following 'esl_csgo'```
+
+----
+
+```@twitch.followed 'esl_csgo'```
+
 
 ### Streams
 

--- a/lib/twitch/client.rb
+++ b/lib/twitch/client.rb
@@ -16,6 +16,7 @@ module Twitch
       @adapter = get_adapter(options[:adapter] || nil)
 
       @base_url = "https://api.twitch.tv/kraken"
+      @alt_base_url = "https://api.twitch.tv/api"
     end
 
     attr_reader :base_url, :redirect_url, :scope
@@ -89,6 +90,15 @@ module Twitch
 
       path = "/channels/"
       url = @base_url + path + channel;
+
+      get(url)
+    end
+
+    def channel_panels(channel = nil)
+      return nil if channel.nil?
+
+      path = "/channels/#{channel}/panels"
+      url = @alt_base_url + path;
 
       get(url)
     end
@@ -170,13 +180,6 @@ module Twitch
     end
 
     # Streams
-
-    def stream(stream_name)
-      path = "/stream/#{stream_name}"
-      url = @base_url + path;
-
-      get(url)
-    end
 
     def stream(stream_name)
       path = "/streams/#{stream_name}"

--- a/lib/twitch/client.rb
+++ b/lib/twitch/client.rb
@@ -355,16 +355,18 @@ module Twitch
 
     # Follows
 
-    def following(channel)
+    def following(channel, options = {})
+      query = build_query_string(options)
       path = "/channels/#{channel}/follows"
-      url = @base_url + path;
+      url = @base_url + path + query;
 
       get(url)
     end
 
-    def followed(username)
+    def followed(username, options = {})
+      query = build_query_string(options)
       path = "/users/#{username}/follows/channels"
-      url = @base_url + path;
+      url = @base_url + path + query
 
       get(url)
     end

--- a/spec/twitch_spec.rb
+++ b/spec/twitch_spec.rb
@@ -57,7 +57,12 @@ describe Twitch do
 		expect( @t.channel("day9tv")[:response] ).to eq 200
 	end
 
-	it 'should get your channel' do
+	it 'should get channel panels' do
+                @t = Twitch.new()
+		expect( @t.channel_panels("esl_csgo")[:response] ).to eq 200
+	end
+
+        it 'should get your channel' do
 		@t = Twitch.new({:access_token => @access_token})
 		expect( @t.channel()[:response] ).to eq 200 unless @access_token.empty?
 	end

--- a/spec/twitch_spec.rb
+++ b/spec/twitch_spec.rb
@@ -29,12 +29,12 @@ describe Twitch do
 
 	it 'should get user (authenticated)' do
 		@t = Twitch.new({:access_token => @access_token})
-		expect( @t.user("day9")[:response] ).to eq 200
+		expect( @t.user("day9")[:response] ).to eq 200 unless @access_token.empty?
 	end
 
 	it 'should get authenticated user' do
 		@t = Twitch.new({:access_token => @access_token})
-		expect( @t.user()[:response] ).to eq 200
+		expect( @t.user()[:response] ).to eq 200 unless @access_token.empty?
 	end
 
 	it 'should not get authenticated user when not authenticated' do
@@ -52,7 +52,6 @@ describe Twitch do
 		expect( @t.team("eg")[:response] ).to eq 200
 	end
 
-
 	it 'should get single channel' do
 		@t = Twitch.new()
 		expect( @t.channel("day9tv")[:response] ).to eq 200
@@ -60,12 +59,12 @@ describe Twitch do
 
 	it 'should get your channel' do
 		@t = Twitch.new({:access_token => @access_token})
-		expect( @t.channel()[:response] ).to eq 200
+		expect( @t.channel()[:response] ).to eq 200 unless @access_token.empty?
 	end
 
 	it 'should edit your channel' do
 		@t = Twitch.new({:access_token => @access_token})
-		expect( @t.edit_channel("Changing API", "Diablo III")[:response] ).to eq 200
+		expect( @t.edit_channel("Changing API", "Diablo III")[:response] ).to eq 200 unless @access_token.empty?
 	end
 
 	# it 'should run a comercial on your channel' do
@@ -108,62 +107,72 @@ describe Twitch do
 		expect(res[:response] ).to eq 200
 		expect(res[:body]["featured"].length).to be > 25
 	end
-	
+
 	it 'should get chat links' do
 	  @t = Twitch.new()
 	  expect( @t.chat_links("day9tv")[:response] ).to eq 200
 	end
-	
+
 	it 'should get chat badges' do
 	  @t = Twitch.new()
 	  expect( @t.badges("day9tv")[:response] ).to eq 200
 	end
-	
+
 	it 'should get chat emoticons' do
 	  @t = Twitch.new()
 	  expect( @t.emoticons()[:response] ).to eq 200
 	end
-	
+
 	it 'should get channel followers' do
 	  @t = Twitch.new()
 	  expect( @t.following("day9tv")[:response] ).to eq 200
 	end
-	
+
+	it 'should get channel followers with page 2' do
+	  @t = Twitch.new()
+	  expect( @t.following("day9tv", offset: 25, limit: 25)[:response] ).to eq 200
+	end
+
 	it 'should get channels followed by user' do
 	  @t = Twitch.new()
 	  expect( @t.followed("day9")[:response] ).to eq 200
 	end
-	
+
+	it 'should get channels followed by user with page 2' do
+	  @t = Twitch.new()
+	  expect( @t.followed("day9", offset: 25, limit: 25)[:response] ).to eq 200
+	end
+
 	it 'should get status of user following channel' do
 	  @t = Twitch.new()
 	  expect( @t.follow_status("day9", "day9tv")[:response] ).to eq 404
 	end
-	
+
 	it 'should get ingests' do
 	  @t = Twitch.new()
 	  expect( @t.ingests[:response] ).to eq 200
 	end
-	
+
 	it 'should get root' do
 	  @t = Twitch.new()
 	  expect( @t.root[:response] ).to eq 200
 	end
-	
+
 	it 'should get your followed streams' do
 	  @t = Twitch.new()
 	  expect( @t.followed_streams() ).to eq false
 	end
-	
+
 	it 'should get your followed videos' do
 	  @t = Twitch.new()
 	  expect( @t.followed_videos() ).to eq false
 	end
-	
+
 	it 'should get top games' do
 	  @t = Twitch.new()
 	  expect( @t.top_games[:response] ).to eq 200
 	end
-	
+
 	it 'should get top videos' do
 	  @t = Twitch.new()
 	  expect( @t.top_videos[:response] ).to eq 200


### PR DESCRIPTION
I added the possibility to send params to `following` and `followed` requests (pagination, limit, etc.) and the tests with it.
I also added a check on `@access_token` to avoid fails when you don't want to use it.
I cleaned by removing useless tabs and lines.