### PR TITLE
Required Client-ID Header for Kraken API calls

### DIFF
--- a/lib/twitch/adapters.rb
+++ b/lib/twitch/adapters.rb
@@ -4,7 +4,7 @@ require 'twitch/adapters/httparty_adapter'
 module Twitch
   module Adapters
     DEFAULT_ADAPTER = Twitch::Adapters::HTTPartyAdapter
-    
+
     def get_adapter(adapter, default_adapter = DEFAULT_ADAPTER)
       begin
         Twitch::Adapters.const_defined?(adapter.to_s)
@@ -15,4 +15,4 @@ module Twitch
       end
     end
   end
-end 
+end

--- a/lib/twitch/adapters/base_adapter.rb
+++ b/lib/twitch/adapters/base_adapter.rb
@@ -1,23 +1,23 @@
 module Twitch
   module Adapters
     class BaseAdapter
-      def self.get(url)
-        request(:get, url)
+      def self.get(url, options = {})
+        request(:get, url, options)
       end
 
-      def self.post(url, options)
+      def self.post(url, options = {})
         request(:post, url, options)
       end
 
-      def self.put(url, options)
+      def self.put(url, options = {})
         request(:put, url, options)
       end
 
-      def self.delete(url)
-        request(:delete, url)
+      def self.delete(url, options = {})
+        request(:delete, url, options)
       end
 
-      def self.request(method, url, options)
+      def self.request(method, url, options = {})
       end
     end
   end

--- a/lib/twitch/adapters/httparty_adapter.rb
+++ b/lib/twitch/adapters/httparty_adapter.rb
@@ -3,8 +3,8 @@ require 'httparty'
 module Twitch
   module Adapters
     class HTTPartyAdapter < BaseAdapter
-      
-      def self.request(method, url, options={})
+
+      def self.request(method, url, options = {})
         res = HTTParty.send(method, url, options)
         {:body => res, :response => res.code}
       end

--- a/lib/twitch/client.rb
+++ b/lib/twitch/client.rb
@@ -7,10 +7,10 @@ module Twitch
     include Twitch::Adapters
 
     def initialize(options = {})
-      @client_id = options[:client_id] || nil
-      @secret_key = options[:secret_key] || nil
-      @redirect_uri = options[:redirect_uri] || nil
-      @scope = options[:scope] || nil
+      @client_id = options[:client_id] || ""
+      @secret_key = options[:secret_key] || ""
+      @redirect_uri = options[:redirect_uri] || ""
+      @scope = options[:scope] || []
       @access_token = options[:access_token] || nil
 
       @adapter = get_adapter(options[:adapter] || nil)

--- a/lib/twitch/request.rb
+++ b/lib/twitch/request.rb
@@ -9,23 +9,30 @@ module Twitch
     end
 
     def get(url)
-      @adapter.get(url)
+      @adapter.get(url, :headers => {
+        'Client-ID' => @client_id
+      })
     end
 
     def post(url, data)
-      @adapter.post(url, :body => data)
+      @adapter.post(url, :body => data, :headers => {
+        'Client-ID' => @client_id
+      })
     end
 
     def put(url, data={})
       @adapter.put(url, :body => data, :headers => {
-          'Accept' => 'application/json',
-          'Content-Type' => 'application/json',
-          'Api-Version' => '2.2'
+        'Accept' => 'application/json',
+        'Content-Type' => 'application/json',
+        'Api-Version' => '2.2',
+        'Client-ID' => @client_id
       })
     end
-    
+
     def delete(url)
-      @adapter.delete(url)
+      @adapter.delete(url, :headers => {
+        'Client-ID' => @client_id
+      })
     end
   end
 end

--- a/spec/helpers/debug_httparty_adapter.rb
+++ b/spec/helpers/debug_httparty_adapter.rb
@@ -1,0 +1,12 @@
+require 'httparty'
+
+module Twitch
+  module Adapters
+    class DebugHTTPartyAdapter < BaseAdapter
+      def self.request(method, url, options={})
+        res = HTTParty.send(method, url, options.merge(:debug_output => $debug_output))
+        {:body => res, :response => res.code}
+      end
+    end
+  end
+end

--- a/spec/helpers/open_uri_adapter.rb
+++ b/spec/helpers/open_uri_adapter.rb
@@ -1,0 +1,20 @@
+require 'open-uri'
+
+module Twitch
+  module Adapters
+    class OpenURIAdapter < BaseAdapter
+      def self.request(method, url, options={})
+        if (method == :get)
+          ret = {}
+
+          open(url) do |io|
+            ret[:body] = JSON.parse(io.read)
+            ret[:response] = io.status.first.to_i
+          end
+
+          ret
+        end
+      end
+    end # class OpenURIAdapter
+  end # module Adapters
+end # module Twitch

--- a/spec/twitch_spec.rb
+++ b/spec/twitch_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Twitch do
 
-	before(:each) do
+  before(:each) do
     @client_id = ""
     @secret_key = ""
     @redirect_uri = "http://localhost:3000/auth"
@@ -12,223 +12,210 @@ describe Twitch do
     @access_token = ""
   end
 
-	it 'should build accurate link' do
-		@t = Twitch.new({
-			:client_id => @client_id,
-			:secret_key => @secret_key,
-			:redirect_uri => @redirect_uri,
-			:scope => ["user_read", "channel_read", "channel_editor", "channel_commercial", "channel_stream", "user_blocks_edit"]
-			})
-		expect( @t.link ).to eq "https://api.twitch.tv/kraken/oauth2/authorize?response_type=code&client_id=#{@client_id}&redirect_uri=#{@redirect_uri}&scope=#{@scope_str}"
-	end
+  it 'should build accurate link' do
+    @t = Twitch.new({
+      :client_id => @client_id,
+      :secret_key => @secret_key,
+      :redirect_uri => @redirect_uri,
+      :scope => ["user_read", "channel_read", "channel_editor", "channel_commercial", "channel_stream", "user_blocks_edit"]
+      })
+    expect( @t.link ).to eq "https://api.twitch.tv/kraken/oauth2/authorize?response_type=code&client_id=#{@client_id}&redirect_uri=#{@redirect_uri}&scope=#{@scope_str}"
+  end
 
-	it 'should get user (not authenticated)' do
-		@t = Twitch.new()
-		expect( @t.user("day9")[:response] ).to eq 200
-	end
+  it 'should get user (not authenticated)' do
+    @t = Twitch.new()
+    expect( @t.user("day9")[:response] ).to eq 200
+  end
 
-	it 'should get user (authenticated)' do
-		@t = Twitch.new({:access_token => @access_token})
-		expect( @t.user("day9")[:response] ).to eq 200 unless @access_token.empty?
-	end
+  it 'should get user (authenticated)' do
+    @t = Twitch.new({:access_token => @access_token})
+    expect( @t.user("day9")[:response] ).to eq 200 unless @access_token.empty?
+  end
 
-	it 'should get authenticated user' do
-		@t = Twitch.new({:access_token => @access_token})
-		expect( @t.user()[:response] ).to eq 200 unless @access_token.empty?
-	end
+  it 'should get authenticated user' do
+    @t = Twitch.new({:access_token => @access_token})
+    expect( @t.user()[:response] ).to eq 200 unless @access_token.empty?
+  end
 
-	it 'should not get authenticated user when not authenticated' do
-		@t = Twitch.new()
-		expect( @t.user() ).to eq false
-	end
+  it 'should not get authenticated user when not authenticated' do
+    @t = Twitch.new()
+    expect( @t.user() ).to eq false
+  end
 
-	it 'should get all teams' do
-		@t = Twitch.new()
-		expect( @t.teams()[:response] ).to eq 200
-	end
+  it 'should get all teams' do
+    @t = Twitch.new()
+    expect( @t.teams()[:response] ).to eq 200
+  end
 
-	it 'should get single team' do
-		@t = Twitch.new()
-		expect( @t.team("eg")[:response] ).to eq 200
-	end
+  it 'should get single team' do
+    @t = Twitch.new()
+    expect( @t.team("eg")[:response] ).to eq 200
+  end
 
-	it 'should get single channel' do
-		@t = Twitch.new()
-		expect( @t.channel("day9tv")[:response] ).to eq 200
-	end
+  it 'should get single channel' do
+    @t = Twitch.new()
+    expect( @t.channel("day9tv")[:response] ).to eq 200
+  end
 
-	it 'should get channel panels' do
-                @t = Twitch.new()
-		expect( @t.channel_panels("esl_csgo")[:response] ).to eq 200
-	end
+  it 'should get channel panels' do
+    @t = Twitch.new()
+    expect( @t.channel_panels("esl_csgo")[:response] ).to eq 200
+  end
 
-        it 'should get your channel' do
-		@t = Twitch.new({:access_token => @access_token})
-		expect( @t.channel()[:response] ).to eq 200 unless @access_token.empty?
-	end
+  it 'should get your channel' do
+    @t = Twitch.new({:access_token => @access_token})
+    expect( @t.channel()[:response] ).to eq 200 unless @access_token.empty?
+  end
 
-	it 'should edit your channel' do
-		@t = Twitch.new({:access_token => @access_token})
-		expect( @t.edit_channel("Changing API", "Diablo III")[:response] ).to eq 200 unless @access_token.empty?
-	end
+  it 'should edit your channel' do
+    @t = Twitch.new({:access_token => @access_token})
+    expect( @t.edit_channel("Changing API", "Diablo III")[:response] ).to eq 200 unless @access_token.empty?
+  end
 
-	# it 'should run a comercial on your channel' do
-	# 	@t = Twitch.new({:access_token => @access_token})
-	#   expect( @t.runCommercial("dustinlakin")[:response] ).to eq 204
-	# end
+  # it 'should run a comercial on your channel' do
+  #   @t = Twitch.new({:access_token => @access_token})
+  #   expect( @t.runCommercial("dustinlakin")[:response] ).to eq 204
+  # end
 
-	it 'should get a single user stream' do
-		@t = Twitch.new()
-		expect( @t.stream("nasltv")[:response] ).to eq 200
-	end
+  it 'should get a single user stream' do
+    @t = Twitch.new()
+    expect( @t.stream("nasltv")[:response] ).to eq 200
+  end
 
-	it 'should get all streams' do
-		@t = Twitch.new()
-		expect( @t.streams()[:response] ).to eq 200
-	end
+  it 'should get all streams' do
+    @t = Twitch.new()
+    expect( @t.streams()[:response] ).to eq 200
+  end
 
-	it 'should get League of Legends streams with +' do
-		@t = Twitch.new()
-		expect( @t.streams({:game => "League+of+Legends"})[:response] ).to eq 200
-	end
+  it 'should get League of Legends streams with +' do
+    @t = Twitch.new()
+    expect( @t.streams({:game => "League+of+Legends"})[:response] ).to eq 200
+  end
 
-	it 'should get League of Legends streams with spaces' do
-		@t = Twitch.new()
-		expect( @t.streams({:game => "League of Legends"})[:response] ).to eq 200
-	end
+  it 'should get League of Legends streams with spaces' do
+    @t = Twitch.new()
+    expect( @t.streams({:game => "League of Legends"})[:response] ).to eq 200
+  end
 
-	it 'should get featured streams' do
-		@t = Twitch.new()
-		res = @t.featured_streams()
+  it 'should get featured streams' do
+    @t = Twitch.new()
+    res = @t.featured_streams()
 
-		expect(res[:response] ).to eq 200
-		expect(res[:body]["featured"].length ).to eq 25
-	end
+    expect(res[:response] ).to eq 200
+    expect(res[:body]["featured"].length ).to eq 25
+  end
 
-	it 'should get more featured streams' do
-		@t = Twitch.new()
-		res = @t.featured_streams({:limit => 100})
+  it 'should get more featured streams' do
+    @t = Twitch.new()
+    res = @t.featured_streams({:limit => 100})
 
-		expect(res[:response] ).to eq 200
-		expect(res[:body]["featured"].length).to be > 25
-	end
+    expect(res[:response] ).to eq 200
+    expect(res[:body]["featured"].length).to be > 25
+  end
 
-	it 'should get chat links' do
-	  @t = Twitch.new()
-	  expect( @t.chat_links("day9tv")[:response] ).to eq 200
-	end
+  it 'should get chat links' do
+    @t = Twitch.new()
+    expect( @t.chat_links("day9tv")[:response] ).to eq 200
+  end
 
-	it 'should get chat badges' do
-	  @t = Twitch.new()
-	  expect( @t.badges("day9tv")[:response] ).to eq 200
-	end
+  it 'should get chat badges' do
+    @t = Twitch.new()
+    expect( @t.badges("day9tv")[:response] ).to eq 200
+  end
 
-	it 'should get chat emoticons' do
-	  @t = Twitch.new()
-	  expect( @t.emoticons()[:response] ).to eq 200
-	end
+  it 'should get chat emoticons' do
+    @t = Twitch.new()
+    expect( @t.emoticons()[:response] ).to eq 200
+  end
 
-	it 'should get channel followers' do
-	  @t = Twitch.new()
-	  expect( @t.following("day9tv")[:response] ).to eq 200
-	end
+  it 'should get channel followers' do
+    @t = Twitch.new()
+    expect( @t.following("day9tv")[:response] ).to eq 200
+  end
 
-	it 'should get channel followers with page 2' do
-	  @t = Twitch.new()
-	  expect( @t.following("day9tv", offset: 25, limit: 25)[:response] ).to eq 200
-	end
+  it 'should get channel followers with page 2' do
+    @t = Twitch.new()
+    expect( @t.following("day9tv", offset: 25, limit: 25)[:response] ).to eq 200
+  end
 
-	it 'should get channels followed by user' do
-	  @t = Twitch.new()
-	  expect( @t.followed("day9")[:response] ).to eq 200
-	end
+  it 'should get channels followed by user' do
+    @t = Twitch.new()
+    expect( @t.followed("day9")[:response] ).to eq 200
+  end
 
-	it 'should get channels followed by user with page 2' do
-	  @t = Twitch.new()
-	  expect( @t.followed("day9", offset: 25, limit: 25)[:response] ).to eq 200
-	end
+  it 'should get channels followed by user with page 2' do
+    @t = Twitch.new()
+    expect( @t.followed("day9", offset: 25, limit: 25)[:response] ).to eq 200
+  end
 
-	it 'should get status of user following channel' do
-	  @t = Twitch.new()
-	  expect( @t.follow_status("day9", "day9tv")[:response] ).to eq 404
-	end
+  it 'should get status of user following channel' do
+    @t = Twitch.new()
+    expect( @t.follow_status("day9", "day9tv")[:response] ).to eq 404
+  end
 
-	it 'should get ingests' do
-	  @t = Twitch.new()
-	  expect( @t.ingests[:response] ).to eq 200
-	end
+  it 'should get ingests' do
+    @t = Twitch.new()
+    expect( @t.ingests[:response] ).to eq 200
+  end
 
-	it 'should get root' do
-	  @t = Twitch.new()
-	  expect( @t.root[:response] ).to eq 200
-	end
+  it 'should get root' do
+    @t = Twitch.new()
+    expect( @t.root[:response] ).to eq 200
+  end
 
-	it 'should get your followed streams' do
-	  @t = Twitch.new()
-	  expect( @t.followed_streams() ).to eq false
-	end
+  it 'should get your followed streams' do
+    @t = Twitch.new()
+    expect( @t.followed_streams() ).to eq false
+  end
 
-	it 'should get your followed videos' do
-	  @t = Twitch.new()
-	  expect( @t.followed_videos() ).to eq false
-	end
+  it 'should get your followed videos' do
+    @t = Twitch.new()
+    expect( @t.followed_videos() ).to eq false
+  end
 
-	it 'should get top games' do
-	  @t = Twitch.new()
-	  expect( @t.top_games[:response] ).to eq 200
-	end
+  it 'should get top games' do
+    @t = Twitch.new()
+    expect( @t.top_games[:response] ).to eq 200
+  end
 
-	it 'should get top videos' do
-	  @t = Twitch.new()
-	  expect( @t.top_videos[:response] ).to eq 200
-	end
+  it 'should get top videos' do
+    @t = Twitch.new()
+    expect( @t.top_videos[:response] ).to eq 200
+  end
 
-	it 'should have a default adapter' do
-		t = Twitch.new
+  it 'should have a default adapter' do
+    @t = Twitch.new
+    expect( @t.adapter ).to eq(Twitch::Adapters::HTTPartyAdapter)
+  end
 
-		expect( t.adapter ).to eq(Twitch::Adapters::HTTPartyAdapter)
-	end
+  it 'should work with a different adapter (open-uri).' do
+    require 'helpers/open_uri_adapter'
 
-	it 'should work with a different adapter (open-uri).' do
-		require 'open-uri' 
+    @t = Twitch.new adapter: Twitch::Adapters::OpenURIAdapter
 
-		module Twitch
-			module Adapters
-				class OpenURIAdapter < BaseAdapter
-					def self.request(method, url, options={})
-						if (method == :get)
-							ret = {}
+    res = @t.featured_streams
 
-							open(url) do |io|
-								ret[:body] = JSON.parse(io.read)
-								ret[:response] = io.status.first.to_i
-							end
+    expect( res[:response]                ).to eq 200
+    expect( res[:body]["featured"].length ).to eq 25
+  end
 
-							ret
-						end
-					end
-				end # class OpenURIAdapter
-			end # module Adapters
-		end # module Twitch
+  it "should fall-back to the default adapter when passed an invalid adapter" do
+    expect( Twitch.new( adapter: false         ).adapter ).to eq( Twitch::Adapters::DEFAULT_ADAPTER )
+    expect( Twitch.new( adapter: 100           ).adapter ).to eq( Twitch::Adapters::DEFAULT_ADAPTER )
+    expect( Twitch.new( adapter: :bad_constant ).adapter ).to eq( Twitch::Adapters::DEFAULT_ADAPTER )
 
-		t = Twitch.new adapter: Twitch::Adapters::OpenURIAdapter
+    @t = Twitch.new
+    @t.adapter = nil
 
-		res = t.featured_streams
+    expect( @t.adapter ).to eq( Twitch::Adapters::DEFAULT_ADAPTER )
+  end
 
-		expect( res[:response]                ).to eq 200
-		expect( res[:body]["featured"].length ).to eq 25
-	end
+  it 'should provide required Client-Id header each request' do
+    require 'helpers/debug_httparty_adapter'
+    $debug_output = StringIO.new
 
-	it "should fall-back to the default adapter when passed an invalid adapter" do
-		expect( Twitch.new( adapter: false         ).adapter ).to eq( Twitch::Adapters::DEFAULT_ADAPTER )
-		expect( Twitch.new( adapter: 100           ).adapter ).to eq( Twitch::Adapters::DEFAULT_ADAPTER )
-		expect( Twitch.new( adapter: :bad_constant ).adapter ).to eq( Twitch::Adapters::DEFAULT_ADAPTER )
+    Twitch.new(adapter: Twitch::Adapters::DebugHTTPartyAdapter, client_id: "test").featured_streams
 
-		t = Twitch.new
-		t.adapter = nil
-
-		expect( t.adapter ).to eq( Twitch::Adapters::DEFAULT_ADAPTER )
-	end
-
+    expect($debug_output.string).to match(/Client-Id: test/)
+  end
 end
-


### PR DESCRIPTION
Hi there. Those changes provided for upcoming API update. 
https://blog.twitch.tv/client-id-required-for-kraken-api-calls-afbb8e95f843#.4f0mstkn9
1) Added required Client-ID header to requests. 
2) Spec for this case
3) Some refactoring 
