### PR TITLE
require date in .gemspec

### DIFF
--- a/twitch.gemspec
+++ b/twitch.gemspec
@@ -1,6 +1,7 @@
 $:.push File.expand_path("../lib", __FILE__)
 
 require "twitch/version"
+require "date"
 
 Gem::Specification.new do |s|
   s.name        = 'twitch'
@@ -14,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.files       = Dir["lib/**/*"]
   s.require_paths = ["lib"]
-  
+
   s.add_dependency('httparty')
   s.add_dependency('json')
   s.add_development_dependency('rspec')


### PR DESCRIPTION
fixes an issue about an exception when using
`bundle outdated`

```
[!] There was an error while loading `twitch.gemspec`: uninitialized constant Date
Did you mean?  Data. Bundler cannot continue.
```

related to https://github.com/bundler/bundler/issues/5470