### PR TITLE
Require date gemspec

### DIFF
--- a/twitch.gemspec
+++ b/twitch.gemspec
@@ -3,7 +3,6 @@ $:.push File.expand_path("../lib", __FILE__)
 require "date"
 require "twitch/version"
 
-
 Gem::Specification.new do |s|
   s.name        = 'twitch'
   s.version     = Twitch::VERSION::STRING

--- a/twitch.gemspec
+++ b/twitch.gemspec
@@ -1,6 +1,8 @@
 $:.push File.expand_path("../lib", __FILE__)
 
+require "date"
 require "twitch/version"
+
 
 Gem::Specification.new do |s|
   s.name        = 'twitch'


### PR DESCRIPTION
This Gem blew up when I ran a 'bundle outdated' because Date isn't required.